### PR TITLE
Adds '-w 0' to keep base64 encoded content in one line

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,7 +4,7 @@ SUCCESS=true
 if [ "${1}" != "true" ]; then
   SUCCESS=false
 fi
-OAS=$(cat oas/swagger.yml | base64)
+OAS=$(cat oas/swagger.yml | base64 -w 0)
 REPORT=$(echo 'tested via RestAssured' | base64)
 
 echo "==> Uploading OAS to Pactflow"


### PR DESCRIPTION
Without this option script didn't work properly on Linux. Curl didn't interpret "content" correctly because it was split into separate lines.